### PR TITLE
Remove VPN promo expiry references

### DIFF
--- a/src/components/Star/WAN/VPNClient/PromoL2TPBanner.tsx
+++ b/src/components/Star/WAN/VPNClient/PromoL2TPBanner.tsx
@@ -62,14 +62,13 @@ export const PromoL2TPBanner = component$<PromoL2TPBannerProps>(
                 HOT DEAL
               </span>
               <span class="ml-2 text-sm font-medium text-white">
-                Limited Time Offer
+                Available Now
               </span>
             </div>
 
             {/* Main Heading */}
             <h2 class="mb-2 text-2xl font-bold tracking-tight text-white md:text-3xl lg:text-4xl">
-              FREE Hyper Speed VPN Until February 2026! Powered by Nasnet
-              Connect
+              FREE Hyper Speed VPN Powered by NasNet Connect
             </h2>
 
             {/* Description */}

--- a/src/components/Star/WAN/VPNClient/Protocols/L2TP/L2TPPromoBanner.tsx
+++ b/src/components/Star/WAN/VPNClient/Protocols/L2TP/L2TPPromoBanner.tsx
@@ -57,8 +57,7 @@ export const L2TPPromoBanner = component$<L2TPPromoBannerProps>(
               <div>
                 <div class="flex items-center">
                   <h3 class="text-text-default text-lg font-bold dark:text-text-dark-default sm:text-xl">
-                    FREE Hyper Speed VPN Until February 2026! Powered by Nasnet
-                    Connect
+                    FREE Hyper Speed VPN Powered by NasNet Connect
                   </h3>
                 </div>
                 <p class="text-text-muted dark:text-text-dark-muted mt-1 max-w-lg text-sm">


### PR DESCRIPTION
Removes the February 2026 expiry language from both L2TP promo banners. Updates the larger banner badge so the offer no longer implies a limited-time expiration. This branch only changes promotional copy; no functional behavior or tests were changed.