### PR TITLE
fix: make IP list updates bi-weekly

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1443,6 +1443,7 @@
   "promo_banner_get_free_access": "Get Free Access",
   "promo_banner_credentials_sent": "Credentials sent! Check your account.",
   "frequency_daily": "Daily",
+  "frequency_biweekly": "Bi-Weekly",
   "frequency_weekly": "Weekly",
   "frequency_monthly": "Monthly",
   "prefixed_tunnel_identifier": "Tunnel identifier (e.g., \"1\", \"main\", \"backup\")",

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -1443,6 +1443,7 @@
   "promo_banner_get_free_access": "دسترسی رایگان بگیرید",
   "promo_banner_credentials_sent": "اطلاعات ورود ارسال شد. حساب خود را بررسی کنید.",
   "frequency_daily": "روزانه",
+  "frequency_biweekly": "دو هفته یک‌بار",
   "frequency_weekly": "هفتگی",
   "frequency_monthly": "ماهانه",
   "prefixed_tunnel_identifier": "شناسه تونل (مثلاً \"1\"، \"main\"، \"backup\")",

--- a/src/components/Core/DataDisplay/FrequencySelector/FrequencySelector.tsx
+++ b/src/components/Core/DataDisplay/FrequencySelector/FrequencySelector.tsx
@@ -6,7 +6,7 @@ import type {
 import { semanticMessages, useMessageLocale } from "~/i18n/semantic";
 
 /**
- * FrequencySelector component for selecting frequency intervals (Daily, Weekly, Monthly).
+ * FrequencySelector component for selecting frequency intervals (Daily, Weekly, Bi-Weekly, Monthly).
  * Displays options as compact selection cards.
  *
  * @example
@@ -35,6 +35,10 @@ export const FrequencySelector = component$<FrequencySelectorProps>((props) => {
       label: semanticMessages.frequency_weekly({}, { locale }),
     },
     {
+      value: "Bi-Weekly",
+      label: semanticMessages.frequency_biweekly({}, { locale }),
+    },
+    {
       value: "Monthly",
       label: semanticMessages.frequency_monthly({}, { locale }),
     },
@@ -52,7 +56,7 @@ export const FrequencySelector = component$<FrequencySelectorProps>((props) => {
       )}
 
       {/* Frequency Cards */}
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-4">
         {frequencyOptions.map((option) => {
           const isSelected = value === option.value;
           const isRecommended = recommendedOption === option.value;

--- a/src/components/Core/DataDisplay/FrequencySelector/FrequencySelector.types.ts
+++ b/src/components/Core/DataDisplay/FrequencySelector/FrequencySelector.types.ts
@@ -1,6 +1,6 @@
 import type { PropFunction } from "@builder.io/qwik";
 
-export type FrequencyValue = "Daily" | "Weekly" | "Monthly";
+export type FrequencyValue = "Daily" | "Weekly" | "Bi-Weekly" | "Monthly";
 
 export interface FrequencySelectorProps {
   /**

--- a/src/components/Star/ConfigGenerator/Extra/DomesticIPS.test.ts
+++ b/src/components/Star/ConfigGenerator/Extra/DomesticIPS.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { generateDomesticIPScript } from "./DomesticIPS";
+import { SConfigGenerator } from "../utils/ConfigGeneratorUtil";
+
+describe("Domestic IP list scheduling", () => {
+    it("defaults the IP list updater to bi-weekly", () => {
+        const result = generateDomesticIPScript("03:00");
+        const configString = SConfigGenerator(result);
+
+        expect(result["/system script"]).toHaveLength(1);
+        expect(result["/system scheduler"]).toHaveLength(1);
+        expect(configString).toContain("name=DomesticIPUpdate");
+        expect(configString).toContain("interval=14d");
+    });
+});

--- a/src/components/Star/ConfigGenerator/Extra/DomesticIPS.ts
+++ b/src/components/Star/ConfigGenerator/Extra/DomesticIPS.ts
@@ -493,7 +493,7 @@ export const DomesticIPsScript: string[] = [
 
 export const generateDomesticIPScript = (
     time: string,
-    interval: FrequencyValue = "Daily",
+    interval: FrequencyValue = "Bi-Weekly",
 ): RouterConfig => {
     // Generate a unique UUID for this script instance
     const generatedUserId = generateUUID();
@@ -512,12 +512,14 @@ export const generateDomesticIPScript = (
         switch (frequency) {
             case "Daily":
                 return "1d";
+            case "Bi-Weekly":
+                return "14d";
             case "Weekly":
                 return "7d";
             case "Monthly":
                 return "30d";
             default:
-                return "1d";
+                return "14d";
         }
     };
 

--- a/src/components/Star/ExtraConfig/RebootUpdate/IPAddressUpdateCard.tsx
+++ b/src/components/Star/ExtraConfig/RebootUpdate/IPAddressUpdateCard.tsx
@@ -47,13 +47,13 @@ export const IPAddressUpdateCard = component$<IPAddressUpdateCardProps>(
             }}
           />
           <FrequencySelector
-            value={ipAddressUpdateInterval.value || "Daily"}
+            value={ipAddressUpdateInterval.value || "Bi-Weekly"}
             onChange$={handleIntervalChange}
             label={semanticMessages.reboot_ip_address_update_frequency(
               {},
               { locale },
             )}
-            recommendedOption="Daily"
+            recommendedOption="Bi-Weekly"
           />
         </div>
       </div>

--- a/src/components/Star/ExtraConfig/RebootUpdate/useRebootUpdate.ts
+++ b/src/components/Star/ExtraConfig/RebootUpdate/useRebootUpdate.ts
@@ -52,10 +52,11 @@ export const useRebootUpdate = () => {
 
   const ipAddressUpdateInterval = useSignal<FrequencyValue | undefined>(
     ctx.state.ExtraConfig.RUI.IPAddressUpdate.interval === "Daily" ||
+      ctx.state.ExtraConfig.RUI.IPAddressUpdate.interval === "Bi-Weekly" ||
       ctx.state.ExtraConfig.RUI.IPAddressUpdate.interval === "Weekly" ||
       ctx.state.ExtraConfig.RUI.IPAddressUpdate.interval === "Monthly"
       ? (ctx.state.ExtraConfig.RUI.IPAddressUpdate.interval as FrequencyValue)
-      : "Daily",
+      : "Bi-Weekly",
   );
 
   return {

--- a/src/components/Star/StarContext/CommonType.ts
+++ b/src/components/Star/StarContext/CommonType.ts
@@ -191,4 +191,4 @@ export type RouterModel =
 
 export type InterfaceType = Ethernet | Wireless | Sfp | LTE;
 
-export type FrequencyValue = "Daily" | "Weekly" | "Monthly";
+export type FrequencyValue = "Daily" | "Weekly" | "Bi-Weekly" | "Monthly";

--- a/src/components/Star/StarContext/ExtraType.ts
+++ b/src/components/Star/StarContext/ExtraType.ts
@@ -1,5 +1,5 @@
 export type ServiceType = "Enable" | "Disable" | "Local";
-export type Interval = "Daily" | "Weekly" | "Monthly" | "";
+export type Interval = "Daily" | "Weekly" | "Bi-Weekly" | "Monthly" | "";
 
 export interface IntervalConfig {
   interval: Interval;

--- a/tests/e2e/advanced-mode-download.spec.ts
+++ b/tests/e2e/advanced-mode-download.spec.ts
@@ -344,7 +344,7 @@ test.describe("Advanced Mode End-to-End", () => {
       .toMatchObject({
         Timezone: "UTC",
         IPAddressUpdate: expect.objectContaining({
-          interval: "Daily",
+          interval: "Bi-Weekly",
         }),
       });
 


### PR DESCRIPTION
## Summary
- Make the easy-mode IP list updater default to bi-weekly and emit `14d`
- Add the bi-weekly frequency option to the selector and keep it ordered after weekly
- Add a test covering the default IP list scheduler interval

## Verification
- `npm run build.types`
- `npm run test:run -- src/components/Star/ConfigGenerator/Extra/DomesticIPS.test.ts`